### PR TITLE
Trimming relay search box content before actually searching

### DIFF
--- a/app/src/main/java/com/networksaremadeofstring/anonionooid/SearchActivity.java
+++ b/app/src/main/java/com/networksaremadeofstring/anonionooid/SearchActivity.java
@@ -71,7 +71,7 @@ public class SearchActivity extends Activity implements RelayListFragment.Callba
 
         Fragment listFragment = new RelayListFragment();
         Bundle searchTermBundle = new Bundle();
-        searchTermBundle.putString(Ooo.ARG_SEARCH,searchTerm);
+        searchTermBundle.putString(Ooo.ARG_SEARCH,searchTerm.trim());
         listFragment.setArguments(searchTermBundle);
         getFragmentManager().beginTransaction()
                 .add(R.id.fragmentHolder, listFragment)


### PR DESCRIPTION
Avoid empty resultsets when user performs a search by pasting whitespace-polluted data in the search field
